### PR TITLE
add bindable class to grid-column-template

### DIFF
--- a/src/grid/columns/grid-column-template.html
+++ b/src/grid/columns/grid-column-template.html
@@ -1,5 +1,5 @@
 <template>
-	<td viewModel.bind="self">
+	<td viewModel.bind="self" class="${class}">
 		<template replaceable part="custom-template">
 		</template>
 	</td>

--- a/src/grid/columns/grid-column-template.js
+++ b/src/grid/columns/grid-column-template.js
@@ -10,6 +10,7 @@ export class GridColumnTemplate {
   @bindable filterable;
   @bindable property;
   @bindable sortable;
+  @bindable class;
 
   constructor(grid) {
     this.grid = grid;


### PR DESCRIPTION
A workaround for #18. 

Semantic UI usage:

```html
<grid-column-template class="collapsing">
    ...
</grid-column-template>
```